### PR TITLE
Shashank/Fixing x-frame meta tag issue

### DIFF
--- a/templates/partials/security.mustache
+++ b/templates/partials/security.mustache
@@ -1,4 +1,3 @@
-	<meta http-equiv="X-Frame-Options" content="SAMEORIGIN" />
 	<style id="antiClickjack">body{display:none !important;}</style>
 	<script type="text/javascript">
 		if (self === top) {


### PR DESCRIPTION
Chrome has been removed supporting X-Frame-Options meta tag from version 52, and it returns an error.