### PR TITLE
Fix react panel draggable

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "gen-translation": "git checkout translation; npm prune ; npm install ; gulp build-min; rm -rf translation; mkdir translation ; cp -r www/ translation/translation; git checkout -- src",
     "deploy-all": "npm run gen-beta; npm run gen-translation; npm run deploy",
     "hunspell": "gulp i18n; cd src/common/translations ; node -e \"var en = require('./en'); console.log(JSON.stringify(en));\">en.json; json2po en.json  >en.po ; po2txt en.po > en.txt; hunspell -p ../../../known_words.txt en.txt && rm *.po *.txt *.json",
-    "publish-latest": "npm test && npm version from-git && npm publish"
+    "publish-latest": "npm test && npm version from-git && npm publish",
+    "start": "npm run dev"
   },
   "author": "Amin Marashi",
   "license": "MIT",

--- a/src/botPage/view/index.js
+++ b/src/botPage/view/index.js
@@ -258,9 +258,7 @@ export default class View {
       .drags()
 
     $('.panel .content')
-      .mousedown((e) => { // prevent content to trigger draggable
-        e.stopPropagation()
-      })
+      .mousedown(e => e.stopPropagation()) // prevent content to trigger draggable
 
     ReactDOM.render(
       <SaveXml

--- a/src/botPage/view/react-components/Panel.js
+++ b/src/botPage/view/react-components/Panel.js
@@ -16,7 +16,10 @@ export class Panel extends PureComponent {
     } = this.props
     return (
       <div
-      ref={el => ($(el).drags())}
+      ref={el => {
+        $(el).drags()
+        $(el).find('.content').mousedown(e => e.stopPropagation())
+      }}
       id={id}
       className="floating-panel"
       >


### PR DESCRIPTION
It's impossible to use the panels that are react components because of the draggable code. Fixed by stopPropagation on the panel contents.