### PR TITLE
Fix block creation error

### DIFF
--- a/src/botPage/view/blockly/blocks/after_purchase/index.js
+++ b/src/botPage/view/blockly/blocks/after_purchase/index.js
@@ -28,6 +28,7 @@ Blockly.JavaScript.after_purchase = (block) => {
   const stack = Blockly.JavaScript.statementToCode(block, 'AFTERPURCHASE_STACK')
   const code = `after_purchase = function after_purchase(){
     try {
+      Blockly.mainWorkspace.getBlockById('${block.id}').select()
       ${stack}
     } catch (e) { 
       if (e.name !== 'BlocklyError') {

--- a/src/botPage/view/blockly/blocks/after_purchase/index.js
+++ b/src/botPage/view/blockly/blocks/after_purchase/index.js
@@ -28,10 +28,7 @@ Blockly.JavaScript.after_purchase = (block) => {
   const stack = Blockly.JavaScript.statementToCode(block, 'AFTERPURCHASE_STACK')
   const code = `after_purchase = function after_purchase(){
     try {
-      var block = Blockly.mainWorkspace.getBlockById('${block.id}')
-      if (block) {
-        block.select()
-      }
+      Blockly.mainWorkspace.highlightBlock('${block.id}')
       ${stack}
     } catch (e) { 
       if (e.name !== 'BlocklyError') {

--- a/src/botPage/view/blockly/blocks/after_purchase/index.js
+++ b/src/botPage/view/blockly/blocks/after_purchase/index.js
@@ -28,7 +28,10 @@ Blockly.JavaScript.after_purchase = (block) => {
   const stack = Blockly.JavaScript.statementToCode(block, 'AFTERPURCHASE_STACK')
   const code = `after_purchase = function after_purchase(){
     try {
-      Blockly.mainWorkspace.getBlockById('${block.id}').select()
+      var block = Blockly.mainWorkspace.getBlockById('${block.id}')
+      if (block) {
+        block.select()
+      }
       ${stack}
     } catch (e) { 
       if (e.name !== 'BlocklyError') {

--- a/src/botPage/view/blockly/blocks/before_purchase/index.js
+++ b/src/botPage/view/blockly/blocks/before_purchase/index.js
@@ -26,7 +26,10 @@ Blockly.JavaScript.before_purchase = (block) => {
   const stack = Blockly.JavaScript.statementToCode(block, 'BEFOREPURCHASE_STACK')
   const code = `before_purchase = function before_purchase(){
     try {
-      Blockly.mainWorkspace.getBlockById('${block.id}').select()
+      var block = Blockly.mainWorkspace.getBlockById('${block.id}')
+      if (block) {
+        block.select()
+      }
       ${stack}
     } catch (e) { 
       if (e.name !== 'BlocklyError') {

--- a/src/botPage/view/blockly/blocks/before_purchase/index.js
+++ b/src/botPage/view/blockly/blocks/before_purchase/index.js
@@ -26,10 +26,7 @@ Blockly.JavaScript.before_purchase = (block) => {
   const stack = Blockly.JavaScript.statementToCode(block, 'BEFOREPURCHASE_STACK')
   const code = `before_purchase = function before_purchase(){
     try {
-      var block = Blockly.mainWorkspace.getBlockById('${block.id}')
-      if (block) {
-        block.select()
-      }
+      Blockly.mainWorkspace.highlightBlock('${block.id}')
       ${stack}
     } catch (e) { 
       if (e.name !== 'BlocklyError') {

--- a/src/botPage/view/blockly/blocks/before_purchase/index.js
+++ b/src/botPage/view/blockly/blocks/before_purchase/index.js
@@ -26,6 +26,7 @@ Blockly.JavaScript.before_purchase = (block) => {
   const stack = Blockly.JavaScript.statementToCode(block, 'BEFOREPURCHASE_STACK')
   const code = `before_purchase = function before_purchase(){
     try {
+      Blockly.mainWorkspace.getBlockById('${block.id}').select()
       ${stack}
     } catch (e) { 
       if (e.name !== 'BlocklyError') {

--- a/src/botPage/view/blockly/blocks/during_purchase/index.js
+++ b/src/botPage/view/blockly/blocks/during_purchase/index.js
@@ -26,7 +26,10 @@ Blockly.JavaScript.during_purchase = (block) => {
   const stack = Blockly.JavaScript.statementToCode(block, 'DURING_PURCHASE_STACK')
   const code = `during_purchase = function during_purchase(){
     try {
-      Blockly.mainWorkspace.getBlockById('${block.id}').select()
+      var block = Blockly.mainWorkspace.getBlockById('${block.id}')
+      if (block) {
+        block.select()
+      }
       ${stack}
     } catch (e) { 
       if (e.name !== 'BlocklyError') {

--- a/src/botPage/view/blockly/blocks/during_purchase/index.js
+++ b/src/botPage/view/blockly/blocks/during_purchase/index.js
@@ -26,6 +26,7 @@ Blockly.JavaScript.during_purchase = (block) => {
   const stack = Blockly.JavaScript.statementToCode(block, 'DURING_PURCHASE_STACK')
   const code = `during_purchase = function during_purchase(){
     try {
+      Blockly.mainWorkspace.getBlockById('${block.id}').select()
       ${stack}
     } catch (e) { 
       if (e.name !== 'BlocklyError') {

--- a/src/botPage/view/blockly/blocks/during_purchase/index.js
+++ b/src/botPage/view/blockly/blocks/during_purchase/index.js
@@ -26,10 +26,7 @@ Blockly.JavaScript.during_purchase = (block) => {
   const stack = Blockly.JavaScript.statementToCode(block, 'DURING_PURCHASE_STACK')
   const code = `during_purchase = function during_purchase(){
     try {
-      var block = Blockly.mainWorkspace.getBlockById('${block.id}')
-      if (block) {
-        block.select()
-      }
+      Blockly.mainWorkspace.highlightBlock('${block.id}')
       ${stack}
     } catch (e) { 
       if (e.name !== 'BlocklyError') {

--- a/src/botPage/view/blockly/blocks/trade/index.js
+++ b/src/botPage/view/blockly/blocks/trade/index.js
@@ -41,6 +41,7 @@ Blockly.Blocks.trade = {
   },
   onchange: function onchange(ev) {
     if (ev.type === 'create') {
+      this.select()
       setBlockTextColor(this)
       for (const blockId of ev.ids) {
         const block = Blockly.mainWorkspace.getBlockById(blockId)
@@ -83,6 +84,7 @@ Blockly.JavaScript.trade = (block) => {
   try {
     ${initialization.trim()}
     trade = function trade(again){
+      Blockly.mainWorkspace.getBlockById('${block.id}').select()
       if (typeof getTradeOptions !== 'undefined') {
         Bot.start('${account.trim()}', getTradeOptions(),
         typeof before_purchase === 'undefined' ? function(){} : before_purchase,

--- a/src/botPage/view/blockly/blocks/trade/index.js
+++ b/src/botPage/view/blockly/blocks/trade/index.js
@@ -84,7 +84,10 @@ Blockly.JavaScript.trade = (block) => {
   try {
     ${initialization.trim()}
     trade = function trade(again){
-      Blockly.mainWorkspace.getBlockById('${block.id}').select()
+      var block = Blockly.mainWorkspace.getBlockById('${block.id}')
+      if (block) {
+        block.select()
+      }
       if (typeof getTradeOptions !== 'undefined') {
         Bot.start('${account.trim()}', getTradeOptions(),
         typeof before_purchase === 'undefined' ? function(){} : before_purchase,

--- a/src/botPage/view/blockly/blocks/trade/index.js
+++ b/src/botPage/view/blockly/blocks/trade/index.js
@@ -41,7 +41,6 @@ Blockly.Blocks.trade = {
   },
   onchange: function onchange(ev) {
     if (ev.type === 'create') {
-      this.select()
       setBlockTextColor(this)
       for (const blockId of ev.ids) {
         const block = Blockly.mainWorkspace.getBlockById(blockId)
@@ -84,10 +83,7 @@ Blockly.JavaScript.trade = (block) => {
   try {
     ${initialization.trim()}
     trade = function trade(again){
-      var block = Blockly.mainWorkspace.getBlockById('${block.id}')
-      if (block) {
-        block.select()
-      }
+      Blockly.mainWorkspace.highlightBlock('${block.id}')
       if (typeof getTradeOptions !== 'undefined') {
         Bot.start('${account.trim()}', getTradeOptions(),
         typeof before_purchase === 'undefined' ? function(){} : before_purchase,

--- a/src/botPage/view/blockly/index.js
+++ b/src/botPage/view/blockly/index.js
@@ -207,6 +207,7 @@ export default class _Blockly {
     let code
     try {
       window.LoopTrap = 99999999999
+      Blockly.mainWorkspace.traceOn(true)
       Blockly.JavaScript
         .INFINITE_LOOP_TRAP = 'if (--window.LoopTrap == 0) { Bot.notifyError("Infinite loop!"); throw "Infinite loop."; }\n'
       disableStrayBlocks()


### PR DESCRIPTION
This will add highlight functionality back, this time using the blockly `workspace.highlightBlock()`, so we don't expect same problems with `block.select()`