### PR TITLE
Fix wrong balance appear in start

### DIFF
--- a/src/botPage/view/index.js
+++ b/src/botPage/view/index.js
@@ -153,9 +153,11 @@ export default class View {
     } else {
       loginButton.hide()
       accountList.show()
+
+      addBalanceForToken(tokenList[0].token)
+
       tokenList.forEach(tokenInfo => {
         let prefix = ''
-        addBalanceForToken(tokenInfo.token)
         if ('isVirtual' in tokenInfo) {
           prefix = (tokenInfo.isVirtual) ? 'Virtual Account' : 'Real Account'
         }


### PR DESCRIPTION
Ashkan reported that on the first try the balance that was being shown for his account was wrong, but when he switched the accounts it was fixed.
I believe there's a race condition because of `addBalanceForToken` being called for every token on the start.
@kellybinary Is there a reason to do this?