### PR TITLE
fix barrier offset predefined value

### DIFF
--- a/src/botPage/view/blockly/blocks/trade/components.js
+++ b/src/botPage/view/blockly/blocks/trade/components.js
@@ -82,7 +82,7 @@ export const barrierOffset = block => {
         if (!block.workspace.getBlockById('BARRIERVALUE')) {
             //eslint-disable-line
             const BarrierValue = block.workspace.newBlock('math_number', 'BARRIERVALUE');
-            BarrierValue.setFieldValue('0.036', 'NUM');
+            BarrierValue.setFieldValue('0.274', 'NUM');
             BarrierValue.setShadow(true);
             BarrierValue.outputConnection.connect(block.getInput('BARRIEROFFSET').connection);
             BarrierValue.initSvg();
@@ -104,7 +104,7 @@ export const secondBarrierOffset = block => {
         if (!block.workspace.getBlockById('SECONDBARRIERVALUE')) {
             //eslint-disable-line
             const BarrierValue = block.workspace.newBlock('math_number', 'SECONDBARRIERVALUE');
-            BarrierValue.setFieldValue('0.036', 'NUM');
+            BarrierValue.setFieldValue('0.274', 'NUM');
             BarrierValue.setShadow(true);
             BarrierValue.outputConnection.connect(block.getInput('SECONDBARRIEROFFSET').connection);
             BarrierValue.initSvg();

--- a/src/botPage/view/blockly/blocks/trade/components.js
+++ b/src/botPage/view/blockly/blocks/trade/components.js
@@ -78,9 +78,9 @@ export const barrierOffset = block => {
             .appendField(new Blockly.FieldDropdown(config.barrierTypes), 'BARRIEROFFSETTYPE_LIST');
     } else {
         const barrierOffsetList = block.getField('BARRIEROFFSETTYPE_LIST');
-        barrierOffsetList.setValue('+');
         if (!block.workspace.getBlockById('BARRIERVALUE')) {
             const barrierValue = block.workspace.newBlock('math_number', 'BARRIERVALUE');
+            barrierOffsetList.setValue('+');
             barrierValue.setFieldValue('0.274', 'NUM');
             barrierValue.setShadow(true);
             barrierValue.outputConnection.connect(block.getInput('BARRIEROFFSET').connection);
@@ -99,9 +99,9 @@ export const secondBarrierOffset = block => {
             .appendField(new Blockly.FieldDropdown(config.barrierTypes), 'SECONDBARRIEROFFSETTYPE_LIST');
     } else {
         const barrierOffsetList = block.getField('SECONDBARRIEROFFSETTYPE_LIST');
-        barrierOffsetList.setValue('-');
         if (!block.workspace.getBlockById('SECONDBARRIERVALUE')) {
             const secondBarrierValue = block.workspace.newBlock('math_number', 'SECONDBARRIERVALUE');
+            barrierOffsetList.setValue('-');
             secondBarrierValue.setFieldValue('0.274', 'NUM');
             secondBarrierValue.setShadow(true);
             secondBarrierValue.outputConnection.connect(block.getInput('SECONDBARRIEROFFSET').connection);

--- a/src/botPage/view/blockly/blocks/trade/components.js
+++ b/src/botPage/view/blockly/blocks/trade/components.js
@@ -76,6 +76,18 @@ export const barrierOffset = block => {
             .setCheck('Number')
             .appendField(`${translate('Barrier Offset')} 1:`)
             .appendField(new Blockly.FieldDropdown(config.barrierTypes), 'BARRIEROFFSETTYPE_LIST');
+    } else {
+        const barrierOffsetList = block.getField('BARRIEROFFSETTYPE_LIST');
+        barrierOffsetList.setValue('+');
+        if (!block.workspace.getBlockById('BARRIERVALUE')) {
+            //eslint-disable-line
+            const BarrierValue = block.workspace.newBlock('math_number', 'BARRIERVALUE');
+            BarrierValue.setFieldValue('0.036', 'NUM');
+            BarrierValue.setShadow(true);
+            BarrierValue.outputConnection.connect(block.getInput('BARRIEROFFSET').connection);
+            BarrierValue.initSvg();
+            BarrierValue.render();
+        }
     }
 };
 
@@ -86,6 +98,18 @@ export const secondBarrierOffset = block => {
             .setCheck('Number')
             .appendField(`${translate('Barrier Offset')} 2:`)
             .appendField(new Blockly.FieldDropdown(config.barrierTypes), 'SECONDBARRIEROFFSETTYPE_LIST');
+    } else {
+        const barrierOffsetList = block.getField('SECONDBARRIEROFFSETTYPE_LIST');
+        barrierOffsetList.setValue('-');
+        if (!block.workspace.getBlockById('SECONDBARRIERVALUE')) {
+            //eslint-disable-line
+            const BarrierValue = block.workspace.newBlock('math_number', 'SECONDBARRIERVALUE');
+            BarrierValue.setFieldValue('0.036', 'NUM');
+            BarrierValue.setShadow(true);
+            BarrierValue.outputConnection.connect(block.getInput('SECONDBARRIEROFFSET').connection);
+            BarrierValue.initSvg();
+            BarrierValue.render();
+        }
     }
 };
 

--- a/src/botPage/view/blockly/blocks/trade/components.js
+++ b/src/botPage/view/blockly/blocks/trade/components.js
@@ -80,13 +80,12 @@ export const barrierOffset = block => {
         const barrierOffsetList = block.getField('BARRIEROFFSETTYPE_LIST');
         barrierOffsetList.setValue('+');
         if (!block.workspace.getBlockById('BARRIERVALUE')) {
-            //eslint-disable-line
-            const BarrierValue = block.workspace.newBlock('math_number', 'BARRIERVALUE');
-            BarrierValue.setFieldValue('0.274', 'NUM');
-            BarrierValue.setShadow(true);
-            BarrierValue.outputConnection.connect(block.getInput('BARRIEROFFSET').connection);
-            BarrierValue.initSvg();
-            BarrierValue.render();
+            const barrierValue = block.workspace.newBlock('math_number', 'BARRIERVALUE');
+            barrierValue.setFieldValue('0.274', 'NUM');
+            barrierValue.setShadow(true);
+            barrierValue.outputConnection.connect(block.getInput('BARRIEROFFSET').connection);
+            barrierValue.initSvg();
+            barrierValue.render();
         }
     }
 };
@@ -102,13 +101,12 @@ export const secondBarrierOffset = block => {
         const barrierOffsetList = block.getField('SECONDBARRIEROFFSETTYPE_LIST');
         barrierOffsetList.setValue('-');
         if (!block.workspace.getBlockById('SECONDBARRIERVALUE')) {
-            //eslint-disable-line
-            const BarrierValue = block.workspace.newBlock('math_number', 'SECONDBARRIERVALUE');
-            BarrierValue.setFieldValue('0.274', 'NUM');
-            BarrierValue.setShadow(true);
-            BarrierValue.outputConnection.connect(block.getInput('SECONDBARRIEROFFSET').connection);
-            BarrierValue.initSvg();
-            BarrierValue.render();
+            const secondBarrierValue = block.workspace.newBlock('math_number', 'SECONDBARRIERVALUE');
+            secondBarrierValue.setFieldValue('0.274', 'NUM');
+            secondBarrierValue.setShadow(true);
+            secondBarrierValue.outputConnection.connect(block.getInput('SECONDBARRIEROFFSET').connection);
+            secondBarrierValue.initSvg();
+            secondBarrierValue.render();
         }
     }
 };


### PR DESCRIPTION
<!--
For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Does not reduce coverage?| Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
- Add default value to the `barrier offset` for single and double barrier
- predefined value barrier offset type, the first barrier is `+` and second barrier is `-`