### PR TITLE
khalid/TradeTable multiple retry for contract refresh

### DIFF
--- a/src/botPage/view/TradeInfoPanel/TradeTable.js
+++ b/src/botPage/view/TradeInfoPanel/TradeTable.js
@@ -114,7 +114,7 @@ export default class TradeTable extends Component {
         let settled = false;
         let delay = 3000;
 
-        const sleep = () => new Promise(resolve => setTimeout(() => resolve(), delay);
+        const sleep = () => new Promise(resolve => setTimeout(() => resolve(), delay));
 
         while (!settled) {
             await sleep();

--- a/src/botPage/view/TradeInfoPanel/TradeTable.js
+++ b/src/botPage/view/TradeInfoPanel/TradeTable.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import json2csv from 'json2csv';
 import React, { Component } from 'react';
 import ReactDataGrid from 'react-data-grid';
@@ -119,7 +120,6 @@ export default class TradeTable extends Component {
             await sleep(delay);
 
             try {
-                alert('Calling API now...');
                 await this.refreshContract(api, contractID);
 
                 const { accountID } = this.props;

--- a/src/botPage/view/TradeInfoPanel/TradeTable.js
+++ b/src/botPage/view/TradeInfoPanel/TradeTable.js
@@ -114,10 +114,10 @@ export default class TradeTable extends Component {
         let settled = false;
         let delay = 3000;
 
-        const sleep = d => new Promise(resolve => setTimeout(() => resolve(), d));
+        const sleep = () => new Promise(resolve => setTimeout(() => resolve(), delay);
 
         while (!settled) {
-            await sleep(delay);
+            await sleep();
 
             try {
                 await this.refreshContract(api, contractID);

--- a/src/botPage/view/TradeInfoPanel/TradeTable.js
+++ b/src/botPage/view/TradeInfoPanel/TradeTable.js
@@ -107,9 +107,28 @@ export default class TradeTable extends Component {
         });
     }
     registerTimeout = (api, contract) => {
-        setTimeout(() => {
+        const exponentialBackoff = (max, delay) => {
+            const { accountID } = this.props;
+            const rows = this.state[accountID].rows.slice();
             const contractID = contract.contract_id;
+
             this.refreshContract(api, contractID);
+
+            let currentStatus = '';
+            rows.forEach(row => {
+                if (row.contract_id === contractID) {
+                    currentStatus = row.contract_status;
+                }
+            });
+
+            if (currentStatus !== translate('Settled') && max > 0) {
+                setTimeout(() => {
+                    exponentialBackoff(max - 1, delay * 2);
+                }, delay * 1000);
+            }
+        };
+        setTimeout(() => {
+            exponentialBackoff(5, 1);
         }, 3000);
     };
     refreshContract(api, contractID) {


### PR DESCRIPTION
<!--
For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Does not reduce coverage?| Yes
| Any Dependency Changes?  | No

<!-- Describe your changes below in as much detail as possible -->

Added multiple API calls to refresh contract information in TradeTable, using exponential backoff for repetition
