### PR TITLE
Fix releases not respecting package-lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ commands:
             - npm-v1-{{ checksum "package.json" }}
             - npm-v1-
       - run:
+          name: Convert npm package-lock to yarn
+          command: yarn import
+      - run:
           name: Install npm modules
           command: yarn
       - save_cache:


### PR DESCRIPTION
Releases in 2021 started to break because the latest 2.3.0 version of
js-Intepreter was imported. packages.json says greater than 2.2.0,
which is satisfied by that. package-lock.json says 2.2.0 but yarn does
not respect npm package-lock.json

Developers work and test using npm, and we keep package-lock up to date.
However the release process uses yarn, which doesn't naturally respect
package-lock.json

Using
```
yarn import
```
converts the package-lock.json to a yarn.lock.

This adds the risk that maybe our package-lock is different from what we
last released in the docker image.
