### PR TITLE
gh-pages command fails with 'fatal: could not create work tree dir, P…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,9 @@ commands:
       - run:
           name: Install and configure dependencies
           command: |
-            sudo npm install -g gh-pages@2.0.1
+            mkdir "${HOME}/.npm-packages"
+            npm config set prefix "${HOME}/.npm-packages"
+            npm i -g gh-pages
             git config user.email "ci-build@binary.com"
             git config user.name "ci-build"
       - add_ssh_keys:
@@ -76,7 +78,7 @@ commands:
             - "01:67:4a:6d:26:9c:70:c4:1a:60:91:88:d9:dd:f0:83"
       - run:
           name: Deploy docs to gh-pages branch
-          command: gh-pages -d www --branch << parameters.target_branch >> --message '[skip ci]'
+          command: /home/circleci/.npm-packages/bin/gh-pages -d www --branch << parameters.target_branch >> --message '[skip ci]'
   docker_build_push:
     description: "Build and Push image to docker hub"
     parameters:


### PR DESCRIPTION
…ermission denied' Error

Because the .cache directory in Circleci does not have the write/create permission to create the repo
By creating .npm-packages directory it will fix

<!--
For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Does not reduce coverage?| Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
