### PR TITLE
Remove old release and use Blue/Green as default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,26 +114,8 @@ commands:
     steps:
       - k8s/install-kubectl
       - run:
-          name: Deploying to k8s cluster for service binary-bot-beta
+          name: Deploying to k8s cluster for service << parameters.k8s_namespace >>
           command: |
-            for SERVER_ID in {1..5}
-            do
-              KUBE_SERVER_REF="KUBE_SERVER_$SERVER_ID"
-              SERVICEACCOUNT_TOKEN_REF="SERVICEACCOUNT_TOKEN_$SERVER_ID"
-              CA_CRT_REF="CA_CRT_$SERVER_ID"
-              if [ ! -z "${!KUBE_SERVER_REF}" ]
-              then
-                echo "Deploying to cluster $SERVER_ID"
-                CA_CRT="${!CA_CRT_REF}"
-                KUBE_SERVER="${!KUBE_SERVER_REF}"
-                SERVICEACCOUNT_TOKEN="${!SERVICEACCOUNT_TOKEN_REF}"
-                deployment_target="bot-binary-com"
-                [ "<< parameters.target >>" == "beta" ] && deployment_target="bot-beta-binary-com"
-                echo $CA_CRT | base64 --decode > ca.crt
-                kubectl --server=${KUBE_SERVER} --certificate-authority=ca.crt --token=$SERVICEACCOUNT_TOKEN set image deployment/${deployment_target} ${deployment_target}=${DOCKHUB_ORGANISATION}/binary-static-bot:${CIRCLE_TAG}
-              fi
-            done
-
             export NAMESPACE=<< parameters.k8s_namespace >>
             git clone https://github.com/binary-com/devops-ci-scripts
             cd devops-ci-scripts/k8s-build_tools
@@ -191,6 +173,7 @@ jobs:
           target: "production"
           k8s_namespace: "bot-binary-com-production"
           k8s_version: ${CIRCLE_TAG}
+      - notify_slack
 
 workflows:
   test:


### PR DESCRIPTION
Switch to blue/green deployment as a default release strategy on staging and production
Before removing the old resources on default namespace we need to merge this

<!--
For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | Yes
| Does not reduce coverage?| Yes
| Any Dependency Changes?  |

<!-- Describe your changes below in as much detail as possible -->
