### PR TITLE
Cloudflare pages: Fix rendering logic and regex.

### DIFF
--- a/src/botPage/view/View.js
+++ b/src/botPage/view/View.js
@@ -848,12 +848,12 @@ function renderReactComponents() {
     const qs = parseQueryString();
     if (new Date().getTime() > Number(bannerToken)) {
         remove('setDueDateForBanner');
-        const getDefaultPath = window.location.href.replace('/bot.html', serialize(qs));
+        const getDefaultPath = window.location.href.replace(/\/bot(\.html)?/, serialize(qs));
         window.location.replace(getDefaultPath);
         return false;
     }
     if (bannerToken === null || bannerToken === undefined) {
-        const getDefaultPath = window.location.href.replace('/bot.html', serialize(qs));
+        const getDefaultPath = window.location.href.replace(/\/bot(\.html)?/, serialize(qs));
         window.location.replace(getDefaultPath);
         document.getElementById('errorArea').remove();
         $('.barspinner').hide();
@@ -867,7 +867,7 @@ function renderReactComponents() {
                     !(
                         typeof window.location !== 'undefined' &&
                         isProduction() &&
-                        window.location.pathname === '/bot.html'
+                        window.location.pathname.includes('/bot')
                     )
                 }
             />,

--- a/src/indexPage/endpoint.js
+++ b/src/indexPage/endpoint.js
@@ -2,18 +2,13 @@ import { get as getStorage, set as setStorage } from '../common/utils/storageMan
 import { generateWebSocketURL, getDefaultEndpoint, generateTestLiveApiInstance } from '../common/appId';
 import { translate } from '../common/i18n';
 
-if (document.location.href.endsWith('/endpoint')) {
-    window.location.replace(`${document.location.href}.html`);
-    throw new Error('Unexpected URL.'); // To prevent URL replace in index and further execution
-}
-
 const MessageProperties = {
     connected: () => `<b>Connected to the Endpoint ${getStorage('config.server_url')}!</b>`,
     error    : () => `Unable to connect to ${getStorage('config.server_url')}. Switching connection to default endpoint.`,
 };
 
 export default function endpoint() {
-    if (!document.location.href.match(/endpoint\.html/)) return false;
+    if (!document.location.pathname.includes('/endpoint')) return false;
     $(document).ready(() => {
         $('#error').hide();
         $('#connected').hide();

--- a/src/indexPage/index.js
+++ b/src/indexPage/index.js
@@ -64,7 +64,7 @@ export const setTimeOutBanner = route => {
             (route === 'index' && !!bannerDisplayed === false) ||
             (route === 'views' && checkifBotRunning() === false)
         ) {
-            const getDefaultPath = window.location.href.replace('/bot.html', serialize(qs));
+            const getDefaultPath = window.location.href.replace(/\/bot(\.html)?/, serialize(qs));
             window.location.replace(getDefaultPath);
             renderBanner();
         } else if (
@@ -79,7 +79,7 @@ export const setTimeOutBanner = route => {
 };
 
 export const renderBanner = () => {
-    if (window.location.href.indexOf('bot.html') === -1 || window.location.pathname === '/movetoderiv.html') {
+    if (window.location.pathname.indexOf('/bot') === -1 || window.location.pathname === '/movetoderiv.html') {
         getComponent();
         render(Component, document.getElementById(dynamicRoutePathanme));
         if (dynamicRoutePathanme === 'bot-landing') {
@@ -101,7 +101,7 @@ const renderElements = () => {
     $('.barspinner').show();
 
     if (!bannerToken) {
-        if (window.location.href.indexOf('bot.html') === -1) {
+        if (window.location.pathname.indexOf('/bot') === -1) {
             renderBanner();
         }
     } else {
@@ -110,7 +110,7 @@ const renderElements = () => {
             renderBanner();
             return false;
         }
-        if (window.location.href.indexOf('bot.html') === -1) {
+        if (window.location.pathname.indexOf('/bot') === -1) {
             render(<Logo />, document.getElementById('binary-logo'));
             render(<Footer />, document.getElementById('footer'));
             isEuCountry().then(isEu => showHideEuElements(isEu));
@@ -132,13 +132,13 @@ const renderElements = () => {
 const loginCheck = () => {
     if (endpoint()) return;
     moveToDeriv();
-    if (window.location.href.indexOf('bot.html') === -1) {
+    if (window.location.pathname.indexOf('/bot') === -1) {
         loadLang();
     }
     $('.show-on-load').show();
     if (bannerToken && window.location.pathname !== '/movetoderiv.html') {
         if (getTokenList().length) {
-            if (!window.location.pathname.includes('/bot.html')) {
+            if (!window.location.pathname.includes('/bot')) {
                 window.location.pathname = `${window.location.pathname.replace(/\/+$/, '')}/bot.html`;
             }
             document.getElementById('bot-main').classList.remove('hidden');

--- a/src/indexPage/react-components/bot-landing/ModalComponent.jsx
+++ b/src/indexPage/react-components/bot-landing/ModalComponent.jsx
@@ -16,7 +16,7 @@ const setDueDateAgain = () => {
 
 const renderBanner = () => {
     const getqueryParameter = document.location.search;
-    const getDefaultPath = window.location.href.replace('/bot.html', getqueryParameter);
+    const getDefaultPath = window.location.href.replace(/\/bot(\.html)?/, getqueryParameter);
     window.location.replace(getDefaultPath);
     render(<ModalComponent />, document.getElementById('bot-landing-alert-popup'));
     render(<BotLanding />, document.getElementById('bot-landing'));


### PR DESCRIPTION
# Changes
- We are hosting backups on Cloudflare pages. Cloudflare pages webserver is rewriting URLs to remove `.html` extensions while still flexibly serving the html file hence has a very little impact in general. We need to take care when testing `href` and `pathname` or replacing parts of URLs.

It has been validated on [test.cf-pages-binary-bot.binary.com](https://test.cf-pages-binary-bot.binary.com/) via card #73837